### PR TITLE
Add support for indexing portein sequences

### DIFF
--- a/bigsi/__main__.py
+++ b/bigsi/__main__.py
@@ -30,9 +30,8 @@ from bigsi.cmds.variant_search import BIGSIAminoAcidMutationSearch
 
 from bigsi.storage import get_storage
 
-from bigsi.utils.cortex import extract_kmers_from_ctx
-from bigsi.utils import seq_to_kmers
 from bigsi.constants import DEFAULT_CONFIG
+from bigsi.utils.sequence_reader import check_file_type
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -117,19 +116,22 @@ class bigsi(object):
 
     @hug.object.cli
     @hug.object.post("/bloom")
-    def bloom(self, ctx, outfile, config=None):
-        """Creates a bloom filter from a sequence file or cortex graph. (fastq,fasta,bam,ctx)
+    def bloom(self, infile, outfile, config=None):
+        """Creates a bloom filter from a sequence file (fasta, fastq) or cortex graph or text file.
 
-        e.g. index insert ERR1010211.ctx
+        BIGSI can build index for both nucleotide and aminoacid sequences.
+        To index aminoacid sequences change the value of sequence_type to aminoacids in the config yaml file\n
+
+        e.g. bigsi bloom ERR1010211.ctx ERR1010211.bloom
 
         """
-        config = get_config_from_file(config)
+        config = get_config_from_file(config)        
         bf = bloom(
             config=config,
             outfile=outfile,
-            kmers=extract_kmers_from_ctx(ctx, config["k"]),
+            kmers=check_file_type(infile, config["k"], config["sequence_type"]),
         )
-
+        
     @hug.object.cli
     @hug.object.post("/build", output_format=hug.output_format.pretty_json)
     def build(

--- a/bigsi/graph/bigsi.py
+++ b/bigsi/graph/bigsi.py
@@ -149,7 +149,7 @@ class BIGSI(SampleMetadata, KmerSignatureIndex):
 
     @classmethod
     def bloom(cls, config, kmers):
-        kmers = convert_query_kmers(kmers)  ## Convert to canonical kmers
+        kmers = convert_query_kmers(kmers, config["sequence_type"])  ## Convert to canonical kmers
         bloomfilter = BloomFilter(m=config["m"], h=config["h"])
         bloomfilter.update(kmers)
         return bloomfilter.bitarray

--- a/bigsi/utils/fncts.py
+++ b/bigsi/utils/fncts.py
@@ -39,13 +39,20 @@ def reverse_comp(s):
     return "".join([COMPLEMENT.get(base, base) for base in reversed(s)])
 
 
-def convert_query_kmers(kmers):
-    for k in kmers:
-        yield convert_query_kmer(k)
+def convert_query_kmers(kmers, seq_type):
+    if seq_type == "nucleotides":
+        for k in kmers:
+            yield convert_query_kmer(k, seq_type)
+    else:
+        for k in kmers:
+            yield k
+    
 
-
-def convert_query_kmer(kmer):
-    return canonical(kmer)
+def convert_query_kmer(kmer, seq_type):
+    if seq_type == "nucleotides":
+        return canonical(kmer)
+    else:
+        return kmer
 
 
 def canonical(k):
@@ -63,3 +70,6 @@ def min_lexo(k):
 def seq_to_kmers(seq, kmer_size):
     for i in range(len(seq) - kmer_size + 1):
         yield seq[i : i + kmer_size]
+        
+        
+    

--- a/bigsi/utils/sequence_reader.py
+++ b/bigsi/utils/sequence_reader.py
@@ -1,0 +1,51 @@
+"""
+Fasta, Fastq, kmers-text file reader.
+"""
+
+from pyfastx import Fasta, Fastq
+from bigsi.utils.cortex import extract_kmers_from_ctx
+from bigsi.utils.fncts import canonical, seq_to_kmers
+
+def extract_kmers_from_fasta(fasta_file, kmer_size, seq_type):
+    if seq_type == 'nucleotides':
+        for name, seq in Fasta(fasta_file, build_index=False):
+            for kmer in seq_to_kmers(seq, kmer_size):
+                yield canonical(kmer)
+    else:
+        for name, seq in Fasta(fasta_file, build_index=False):
+            for kmer in seq_to_kmers(seq, kmer_size):
+                yield kmer
+        
+
+def extract_kmers_from_fastq(fastq_file, kmer_size, seq_type):
+    if seq_type == 'nucleotides':
+        for name,seq,quality in Fastq(fastq_file, build_index=False):
+            for kmer in seq_to_kmers(seq, kmer_size):
+                yield canonical(kmer)
+    else:
+        for name,seq,quality in Fastq(fastq_file, build_index=False):
+            for kmer in seq_to_kmers(seq, kmer_size):
+                yield kmer
+                
+
+def extract_kmers_from_kmers_txt(kmers_txt, seq_type):
+    if seq_type == 'nucleotides':
+        for kmer in open(kmers_txt):
+            yield canonical(kmer.strip())
+    else:
+        for kmer in open(kmers_txt):
+            yield kmer.strip()
+
+
+def check_file_type(in_file, kmer_size, seq_type):
+    line = ""
+    with open(in_file, "rb") as in_f:
+        line = in_f.readline()
+    if line[:6] == b"CORTEX":
+        return extract_kmers_from_ctx(in_file, kmer_size)
+    elif line.startswith(b">"):
+        return extract_kmers_from_fasta(in_file, kmer_size, seq_type)
+    elif line.startswith(b"@"):
+        return extract_kmers_from_fastq(in_file, kmer_size, seq_type)
+    elif line.isalpha:
+        return extract_kmers_from_kmers_txt(in_file, seq_type)

--- a/example-data/configs/berkeleydb.yaml
+++ b/example-data/configs/berkeleydb.yaml
@@ -2,6 +2,7 @@ h: 3
 k: 31
 m: 1000
 nproc: 1
+sequence_type: nucleotides
 storage-engine: berkeleydb
 storage-config:
   filename: test-berkeleydb

--- a/example-data/configs/redis.yaml
+++ b/example-data/configs/redis.yaml
@@ -1,6 +1,7 @@
 h: 3
 k: 31
 m: 1000
+sequence_type: nucleotides
 storage-engine: redis
 storage-config:
   host: localhost

--- a/example-data/configs/rocks.yaml
+++ b/example-data/configs/rocks.yaml
@@ -2,6 +2,7 @@ h: 3
 k: 31
 m: 1000
 nproc: 4
+sequence_type: nucleotides
 max_build_mem_bytes: "20GB"
 low_mem_build: false
 storage-engine: rocksdb

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ biopython
 pyyaml>=4.2b1
 humanfriendly
 pyfasta==0.5.2
+pyfastx==0.6.5
 
 # Tests
 psutil


### PR DESCRIPTION
This pull request attempts to add support to index amino acid sequences

Changes to be made:
1) Update the config YAML files in the docs (https://bigsi.readme.io/docs/your-first-bigsi):
By default now the code expects to find the following key:value pair in the config YAML file.
**sequence_type: nucleotides**
                **or**
**sequence_type: aminoacids**
I have updated the YAML files found in example-data/configs to adapt this.

The benefits of this PR are:
1. Building an index for protein sequences
2. Building an index directly from fasta, fastq, and a list of kmers in a .txt file